### PR TITLE
Navigation title backwards compatibility

### DIFF
--- a/Sources/AckGenUI/AcknowledgementsList.swift
+++ b/Sources/AckGenUI/AcknowledgementsList.swift
@@ -11,14 +11,9 @@ import SwiftUI
 public struct AcknowledgementsList: View {
     typealias Acknowledgement = AckGen.Acknowledgement
 
-    private let plistName: String
     private let title: String
 
-    public init(
-        plistName: String = "Acknowledgements",
-        title: String = "Acknowledgements"
-    ) {
-        self.plistName = plistName
+    public init(title: String = "Acknowledgements") {
         self.title = title
     }
 
@@ -30,7 +25,7 @@ public struct AcknowledgementsList: View {
                 Text(ack.title)
             }
         }
-            .navigationTitle(title)
+            .customNavigationTitle(title)
             .onAppear {
                 self.acknowledgements = Acknowledgement.all()
             }
@@ -46,6 +41,6 @@ public struct AcknowledgementDetailsView: View {
             Text(acknowledgement.license)
                 .padding()
         }
-            .navigationTitle(acknowledgement.title)
+            .customNavigationTitle(acknowledgement.title)
     }
 }

--- a/Sources/AckGenUI/CustomNavigationTitle.swift
+++ b/Sources/AckGenUI/CustomNavigationTitle.swift
@@ -1,0 +1,37 @@
+//
+//  CustomNavigationTitle.swift
+//  AckGen
+//
+//  Created by Damjan Dabo on 25.10.22.
+//
+
+import SwiftUI
+
+@available(iOS 14, *)
+struct NavigationTitleViewModifier: ViewModifier {
+    var text: String
+
+    func body(content: Content) -> some View {
+        content.navigationTitle(text)
+    }
+}
+
+struct NavigationBarTitleViewModifier: ViewModifier {
+    var text: String
+
+    func body(content: Content) -> some View {
+        content.navigationBarTitle(text)
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func customNavigationTitle(_ text: String) -> some View {
+        if #available(iOS 14, *) {
+            self.modifier(NavigationTitleViewModifier(text: text))
+        }
+        else {
+            self.modifier(NavigationBarTitleViewModifier(text: text))
+        }
+    }
+}


### PR DESCRIPTION
Fixes navigation title backwards compatibility by adding custom view modifier.
Removes plistName from AcknowledgementsList for now as it's not used.