### PR TITLE
Support LICENSE.md files

### DIFF
--- a/Sources/AckGenCLI/AckGen.swift
+++ b/Sources/AckGenCLI/AckGen.swift
@@ -14,7 +14,7 @@ struct AckGenCLI {
     static func main() {
         print("Generating Acknowledgements file")
 
-        let licenseFiles: [String] = ["LICENSE", "LICENSE.txt"]
+        let licenseFiles: [String] = ["LICENSE", "LICENSE.txt", "LICENSE.md"]
         
         let arguments: [String] = Array(CommandLine.arguments.dropFirst())
 


### PR DESCRIPTION
Not all repo's have the specific `LICENSE` or `LICENSE.txt` file that AckGen is searching for. Sometimes, license files are named `LICENSE.md`

An example of a license with the md extension is https://github.com/mapbox/turf-swift