### PR TITLE
Add support for selecting a different bundle

### DIFF
--- a/Sources/AckGen/Acknowledgement.swift
+++ b/Sources/AckGen/Acknowledgement.swift
@@ -17,12 +17,16 @@ public struct Acknowledgement: Codable {
         self.license = license
     }
 
-
-    /// <#Description#>
-    /// - Parameter plistName: the property list's filename without extension
-    /// - Returns: Array of objects containing title and
-    public static func all(fromPlist plistName: String = "Acknowledgements") -> [Acknowledgement] {
-        guard let path = Bundle.main.path(forResource: plistName, ofType: "plist"),
+    /// Fetch all the acknowledgements from the acknowledgement property list's file.
+    /// - Parameters:
+    ///   - plistName: the property list's filename without extension. Default to `Acknowledgements`.
+    ///   - bundle: the bundle where the plist file is located. Default to the main bundle.
+    /// - Returns: Array of objects containing title and licence.
+    public static func all(
+        fromPlist plistName: String = "Acknowledgements",
+        in bundle: Bundle = .main
+    ) -> [Acknowledgement] {
+        guard let path = bundle.path(forResource: plistName, ofType: "plist"),
               let xml = FileManager.default.contents(atPath: path),
               let acks = try? PropertyListDecoder().decode([Acknowledgement].self, from: xml) else { return [] }
         return acks.sorted(by: { $0.title.lowercased() < $1.title.lowercased() })

--- a/Sources/AckGen/Acknowledgement.swift
+++ b/Sources/AckGen/Acknowledgement.swift
@@ -19,8 +19,8 @@ public struct Acknowledgement: Codable {
 
     /// Fetch all the acknowledgements from the acknowledgement property list's file.
     /// - Parameters:
-    ///   - plistName: the property list's filename without extension. Default to `Acknowledgements`.
-    ///   - bundle: the bundle where the plist file is located. Default to the main bundle.
+    ///   - plistName: the property list's filename without extension. Defaults to `Acknowledgements`.
+    ///   - bundle: the bundle where the plist file is located. Defaults to the main bundle.
     /// - Returns: Array of objects containing title and licence.
     public static func all(
         fromPlist plistName: String = "Acknowledgements",

--- a/Sources/AckGenUI/AcknowledgementsList.swift
+++ b/Sources/AckGenUI/AcknowledgementsList.swift
@@ -13,15 +13,18 @@ public struct AcknowledgementsList: View {
 
     private let title: String
     private let plistName: String
+    private let bundle: Bundle
     private let otherAcknowledgements: [Acknowledgement]
 
     public init(
         title: String = "Acknowledgements",
         plistName: String = "Acknowledgements",
+        bundle: Bundle = .main,
         otherAcknowledgements: [AckGen.Acknowledgement] = []
     ) {
         self.title = title
         self.plistName = plistName
+        self.bundle = bundle
         self.otherAcknowledgements = otherAcknowledgements
     }
 
@@ -35,7 +38,7 @@ public struct AcknowledgementsList: View {
         }
         .customNavigationTitle(title)
         .onAppear {
-            self.acknowledgements = (Acknowledgement.all(fromPlist: plistName) + otherAcknowledgements).sorted()
+            self.acknowledgements = (Acknowledgement.all(fromPlist: plistName, in: bundle) + otherAcknowledgements).sorted()
         }
     }
 }


### PR DESCRIPTION
This PR adds support for selecting a different bundle instead of always using the main bundle when generating acknowledgements. The bundle parameter is optional and default to the main bundle to keep the simple syntax of `Acknowledgements.all()`.

```swift
if let bundle = Bundle(identifier: "my.bundle") {
    let ack = Acknowledgements.all(in: bundle)
}
```

I updated the documentation of the `.all()` function.

I also updated the `AcknowledgementsList` component with the same bundle parameter.

```swift
struct ContentView: View {
    let bundle: Bundle

    var body: some View {
        AcknowledgementsList(bundle: bundle)
    }
}
```

Let me know if you have any comment. Thanks for this great package!