### PR TITLE
Fix path detection when Build appears in directory names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ This can be used to feed a SwiftUI List or UITableView dataSource in your app.
 2. Add the following as a Run Script for your target in Xcode
 
 ```sh
-DIR=$PROJECT_TEMP_DIR/../../../SourcePackages/checkouts/AckGen
+# Calculate the package path dynamically (handles "Build" in usernames/project paths)
+BASE_DIR="${PROJECT_TEMP_DIR%/Build/*}"
+DIR="$BASE_DIR/SourcePackages/checkouts/AckGen"
+
 if [ -d "$DIR" ]; then
-  cd $DIR
-  SDKROOT=(xcrun --sdk macosx --show-sdk-path)
+  cd "$DIR"
+  SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
   swift run ackgen
 else
   echo "warning: AckGen not found. Please install the package via SPM (https://github.com/MartinP7r/AckGen#installation)"

--- a/Sources/AckGenCLI/AckGen.swift
+++ b/Sources/AckGenCLI/AckGen.swift
@@ -39,7 +39,13 @@ struct AckGen: ParsableCommand {
 
         let plistPath: String = output ?? "\(srcRoot)/Acknowledgements.plist"
 
-        let packageCachePath = tempDirPath.components(separatedBy: "/Build/")[0] + "/SourcePackages/checkouts"
+        // Find the last occurrence of "/Build/" to handle edge cases like "Build" in username
+        let packageCachePath: String
+        if let range = tempDirPath.range(of: "/Build/", options: .backwards) {
+            packageCachePath = String(tempDirPath[..<range.lowerBound]) + "/SourcePackages/checkouts"
+        } else {
+            packageCachePath = tempDirPath.components(separatedBy: "/Build/")[0] + "/SourcePackages/checkouts"
+        }
         let fman = FileManager.default
 
         let packageDirectories = try fman.contentsOfDirectory(atPath: packageCachePath)


### PR DESCRIPTION
## Summary
- Fix `components(separatedBy: "/Build/")[0]` splitting on first occurrence instead of last
- Use `.range(of: "/Build/", options: .backwards)` to match bash `${x%/Build/*}` behavior
- Update README run script to use robust parameter expansion with proper quoting

Supersedes #37 (which was based on stale pre-SwiftArgumentParser code and had significant scope creep).

## Test plan
- [ ] Verify path calculation works for standard Xcode DerivedData paths
- [ ] Verify edge case: username containing "Build" (e.g., `/Users/Build/Projects/...`)
- [ ] Build and run on a project with SPM dependencies