### PR TITLE
Use case-insensitive locale-aware sorting for Acknowledgements

### DIFF
--- a/Sources/AckGenCore/Acknowledgement.swift
+++ b/Sources/AckGenCore/Acknowledgement.swift
@@ -36,12 +36,12 @@ public struct Acknowledgement: Codable {
         guard let path = bundle.path(forResource: plistName, ofType: "plist"),
               let xml = FileManager.default.contents(atPath: path),
               let acks = try? PropertyListDecoder().decode([Acknowledgement].self, from: xml) else { return [] }
-        return acks.sorted(by: { $0.title.lowercased() < $1.title.lowercased() })
+        return acks.sorted()
     }
 }
 
 extension Acknowledgement: Comparable {
     public static func < (lhs: Acknowledgement, rhs: Acknowledgement) -> Bool {
-        lhs.title < rhs.title
+        lhs.title.localizedStandardCompare(rhs.title) == .orderedAscending
     }
 }

--- a/Tests/AckGenTests/AckGenTests.swift
+++ b/Tests/AckGenTests/AckGenTests.swift
@@ -64,7 +64,7 @@ final class AckGenTests: XCTestCase {
 
         let bundle = Bundle(for: AckGenTests.self)
         // Can't easily inject a custom bundle path, so just verify the sorting logic directly
-        let sorted = items.sorted(by: { $0.title.lowercased() < $1.title.lowercased() })
+        let sorted = items.sorted()
         XCTAssertEqual(sorted.map(\.title), ["apple", "Mango", "Zebra"])
 
         try FileManager.default.removeItem(at: plistPath)

--- a/Tests/AckGenTests/AcknowledgementTests.swift
+++ b/Tests/AckGenTests/AcknowledgementTests.swift
@@ -27,9 +27,7 @@ final class AcknowledgementTests: XCTestCase {
         XCTAssertFalse(ackB < ackA)
     }
 
-    func testSortingIsCaseSensitive() {
-        // Note: Comparable implementation uses case-sensitive sorting
-        // This differs from Acknowledgement.all() which uses case-insensitive
+    func testSortingIsCaseInsensitive() {
         let acks = [
             Acknowledgement(title: "Zebra", license: "License 1"),
             Acknowledgement(title: "apple", license: "License 2"),
@@ -38,10 +36,10 @@ final class AcknowledgementTests: XCTestCase {
 
         let sorted = acks.sorted()
 
-        // Case-sensitive: uppercase comes before lowercase in ASCII
-        XCTAssertEqual(sorted[0].title, "Banana")
-        XCTAssertEqual(sorted[1].title, "Zebra")
-        XCTAssertEqual(sorted[2].title, "apple")
+        // Case-insensitive: alphabetical order regardless of case
+        XCTAssertEqual(sorted[0].title, "apple")
+        XCTAssertEqual(sorted[1].title, "Banana")
+        XCTAssertEqual(sorted[2].title, "Zebra")
     }
 
     func testCodingKeys() {


### PR DESCRIPTION
## Summary
- Unify sorting behavior: `Comparable` now uses `localizedStandardCompare` instead of plain `<`
- `all()` delegates to `.sorted()` instead of using a separate `.lowercased()` closure
- All 16 tests pass

Supersedes #38 (which targeted the already-merged `feature/bug-fixes-and-tests` branch).

## Test plan
- [x] All existing tests pass (16/16)
- [x] `testSortingIsCaseInsensitive` validates ["apple", "Banana", "Zebra"] ordering